### PR TITLE
Prevent automatic zpool imports, prune package list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.xz
 *.iso
 xbps-cachedir*
+hrmpf-include

--- a/hrmpf.packages
+++ b/hrmpf.packages
@@ -118,7 +118,6 @@ pptpclient
 procmail
 radvd
 redsocks
-rfkill
 rpcbind
 s6
 s6-linux-utils
@@ -138,7 +137,6 @@ tcpflow
 tcping
 tcptrack
 tinyssh
-tlsdate
 tor
 traceroute
 vde2
@@ -211,7 +209,6 @@ irqbalance
 jo
 jq
 kbd
-kbd-data
 kexec-tools
 less
 linux-firmware
@@ -384,7 +381,6 @@ zstd
 zutils
 
 # security
-acme-client
 age
 ccrypt
 chntpw
@@ -399,7 +395,6 @@ haveged
 john
 keyutils
 kismet
-libressl
 masscan
 minisign
 nmap
@@ -503,8 +498,6 @@ backupninja
 borg
 btrbk
 bup
-burp-client
-burp-server
 csync
 csync2
 dar
@@ -512,7 +505,6 @@ duplicity
 dvdbackup
 fsarchiver
 mt-st
-obnam
 rdiff-backup
 rdumpfs
 restic
@@ -596,7 +588,6 @@ tinyproxy
 unbound
 wireguard
 xinetd
-zerotier-one
 
 # office
 sc

--- a/mkhrmpf.sh
+++ b/mkhrmpf.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# Create an empty zpool.cache to prevent importing at boot
+mkdir -p hrmpf-include/etc/zfs
+: > hrmpf-include/etc/zfs/zpool.cache
+
 ./mklive.sh \
 	-T "hrmpf live/rescue system" \
 	-C "loglevel=6 printk.time=1 consoleblank=0 net.ifnames=0" \
@@ -14,3 +18,4 @@
 	-B extra/grub2.iso \
 	-p "$(grep '^[^#].' hrmpf.packages)" \
 	-A "gawk tnftp inetutils-hostname libressl-netcat dash vim-common" \
+	-I hrmpf-include \


### PR DESCRIPTION
In the first commit, I've pruned packages that have been removed from xbps-src. (I've also removed `extrace` because it conflicts with `procps-ng` and causes XBPS to fail.)

In the second commit, I use the `-I` flag for `mklive.sh` to install an empty `/etc/zfs/zpool.cache` into the image. Testing in a qemu VM confirms that this is enough to prevent the importing of ZFS pools at boot. This causes a warning about a missing or corrupt cache file when `03-filesystems.sh` tries to import, but this is a harmless error. This is not necessarily the cleanest solution, but it seems to be the simplest.