### PR TITLE
Remove csync

### DIFF
--- a/hrmpf.packages
+++ b/hrmpf.packages
@@ -506,7 +506,6 @@ backupninja
 borg
 btrbk
 bup
-csync
 csync2
 dar
 duplicity


### PR DESCRIPTION
csync was removed from void-packages in https://github.com/void-linux/void-packages/commit/1931fd575513df898d94733ec9d298aa21a12fd7