### PR TITLE
mkhrmpf: use repo-default

### DIFF
--- a/hrmpf.packages
+++ b/hrmpf.packages
@@ -506,7 +506,6 @@ backupninja
 borg
 btrbk
 bup
-csync
 csync2
 dar
 duplicity

--- a/mkhrmpf.sh
+++ b/mkhrmpf.sh
@@ -19,8 +19,8 @@ printf '%s\n' '-*' 'e*' 'Eauth.*' 'Eauthpriv.*' > hrmpf-include/var/log/socklog/
 ./mklive.sh \
 	-T "hrmpf live/rescue system" \
 	-C "loglevel=6 printk.time=1 consoleblank=0 net.ifnames=0" \
-	-r http://alpha.de.repo.voidlinux.org/current \
-	-r http://alpha.de.repo.voidlinux.org/current/nonfree \
+	-r https://repo-default.voidlinux.org/current \
+	-r https://repo-default.voidlinux.org/current/nonfree \
 	-S 2048 \
 	-i zstd \
 	-s "xz -Xbcj x86" \


### PR DESCRIPTION
alpha.de still exists in a few other places but that seems to be imported from mklive and could be solved by rebasing