### PR TITLE
mkhrmpf.sh: allow passing arguments to mklive

### DIFF
--- a/mkhrmpf.sh
+++ b/mkhrmpf.sh
@@ -34,3 +34,4 @@ touch hrmpf-include/etc/skel/.vimrc hrmpf-include/root/.vimrc
 	-A "gawk tnftp inetutils-hostname libressl-netcat dash vim-common" \
 	-S "acpid binfmt-support dhcpcd gpm sshd" \
 	-I hrmpf-include \
+	"$@"


### PR DESCRIPTION
Same as https://github.com/void-linux/void-mklive/pull/316; mklive accepts multiple instances of `-SIp`