### PR TITLE
Exclude removed packages

### DIFF
--- a/hrmpf.packages
+++ b/hrmpf.packages
@@ -172,7 +172,6 @@ colordiff
 convmv
 cpulimit
 cpupower
-crda
 cronie
 curl
 daemonize
@@ -530,7 +529,6 @@ rsync
 snapraid
 snazzer
 unison
-zbackup
 zpaq
 
 # shells


### PR DESCRIPTION
It seems a few packages have recently been dropped from the repositories: `crda` and `zbackup`. Regarding `crda`, I found [this](https://github.com/void-linux/void-packages/pull/47749/commits/d7a6d2ad3b16433fda0c15839675cb1e91dd5300). Regarding `zbackup`, I've no luck googling anything relevant. I'd be grateful for some link to the change for better understanding of Void Linux.